### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -3,7 +3,7 @@ function git::is_stashed
 end
 
 function git::get_ahead_count
-  echo (command git log ^/dev/null | grep '^commit' | wc -l | tr -d " ")
+  echo (command git log 2> /dev/null | grep '^commit' | wc -l | tr -d " ")
 end
 
 function git::branch_name


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618