### PR TITLE
Change ahead count to count commits ahead of origin and added behind count

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -3,7 +3,8 @@ function git::is_stashed
 end
 
 function git::get_ahead_count
-  echo (command git log 2> /dev/null | grep '^commit' | wc -l | tr -d " ")
+  set -l branch_name (git::branch_name)
+  echo (command git log origin/$branch_name..$branch_name 2> /dev/null | grep '^commit' | wc -l | tr -d " ")
 end
 
 function git::branch_name

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -13,7 +13,11 @@ function git::get_behind_count
 end
 
 function git::branch_name
-  command git symbolic-ref --short HEAD
+  if git symbolic-ref --short HEAD 2> /dev/null
+    echo (command git symbolic-ref --short HEAD 2> /dev/null)
+  else
+    echo (command git rev-parse --short HEAD)
+  end
 end
 
 function git::is_touched

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -7,6 +7,11 @@ function git::get_ahead_count
   echo (command git log origin/$branch_name..$branch_name 2> /dev/null | grep '^commit' | wc -l | tr -d " ")
 end
 
+function git::get_behind_count
+  set -l branch_name (git::branch_name)
+  echo (command git log $branch_name..origin/$branch_name 2> /dev/null | grep '^commit' | wc -l | tr -d " ")
+end
+
 function git::branch_name
   command git symbolic-ref --short HEAD
 end
@@ -32,11 +37,18 @@ function fish_right_prompt
         echo ""
       end
     end)(__batman_color_fst)(git::branch_name)(__batman_color_snd)(begin
-      set -l count (git::get_ahead_count)
+        set -l count (git::get_ahead_count)
         if test $count -eq 0
           echo ""
         else
           echo (__batman_color_trd)"+"(__batman_color_fst)$count
+        end
+    end)(begin
+        set -l count (git::get_behind_count)
+        if test $count -eq 0
+          echo ""
+        else
+          echo (__batman_color_trd)"-"(__batman_color_fst)$count
         end
     end)(__batman_color_snd)") "(__batman_color_off)
   end


### PR DESCRIPTION
The previous ahead count was counting how many commits ahead of the initial commit I believe. This change should make it display only the number of commits ahead of origin on the same branch.

In a similar fashion added a minimal display of commits behind origin to be shown after the ahead value (if it exists).

![image](https://user-images.githubusercontent.com/15388206/66257377-39384d80-e74d-11e9-845a-1f14701c670b.png)
