### PR TITLE
Fix fish_prompt for special working directories

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -6,11 +6,11 @@ function fish_prompt
   set -l pwd (prompt_pwd)
   set -l base (basename "$pwd")
 
-  set -l expr "s|~|"(__batman_color_fst)"^^"(__batman_color_off)"|g; \
+  set -l expr "s|^~|"(__batman_color_fst)"^^"(__batman_color_off)"|g; \
                s|/|"(__batman_color_snd)"/"(__batman_color_off)"|g;  \
-               s|"$base"|"(__batman_color_fst)$base(__batman_color_off)" |g"
+               s|"$base\$"|"(__batman_color_fst)$base(__batman_color_off)"|g"
 
-  echo -n (echo "$pwd" | sed -e $expr)(__batman_color_off)
+  echo -n (echo "$pwd" | sed -e $expr)(__batman_color_off)" "
 
   for color in $colors
     echo -n (set_color $color)">"


### PR DESCRIPTION
Before the change, working under directories like `/t/mm` will print a prompt like `/t/m m >>>` where you can find an unexpected blank in the middle. I didn't look into the exact cause but I presume it was probably caused by the escaped ANSI color commands (where `m` is a common character). The PR also fixes a problem for the substitution of `~` for those directories like `/t/a~`.

The fix applies to the sed command to 
- Restrict the substitution to the `~` at the beginning, which is supposed to be the home. 
- Restrict the substitution to the `$base` before the end, which is the only right location.
- Add the trailing blank for home. Before the change it's `^^>>>`, now it should be `^^ >>>` correctly.